### PR TITLE
Update to PX4-Autopilot v1.13

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,20 @@
 SHELL:=/bin/bash
 
-gazebo: gscam micrortps_agent qgc
+gazebo: gscam micrortps_agent qgc gisnav
 	cd ${HOME}/PX4-Autopilot && \
 	make HEADLESS=${GAZEBO_HEADLESS} px4_sitl_rtps gazebo_typhoon_h480__ksql_airport
+
+gisnav:
+	if [ -z "${WITH_GISNAV}" ]; \
+		then \
+			echo "WITH_GISNAV env variable not provided for build, will not attempt to run GISNav."; \
+		else \
+			source /opt/ros/foxy/setup.bash; \
+			source ${HOME}/colcon_ws/install/setup.bash; \
+			cd ${HOME}/colcon_ws; \
+			nohup ros2 run gisnav mock_gps_node --ros-args --log-level info \
+				--params-file src/gisnav/config/typhoon_h480__ksql_airport.yaml & \
+	fi
 
 gscam:
 	source /opt/ros/foxy/setup.bash && \

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@ gazebo: gscam micrortps_agent qgc
 
 gscam:
 	source /opt/ros/foxy/setup.bash && \
-	source $HOME/colcon_ws/install/setup.bash && \
+	source ${HOME}/colcon_ws/install/setup.bash && \
 	cd ${HOME}/colcon_ws && \
 	nohup ros2 run gscam gscam_node --ros-args --params-file ${HOME}/gscam_params.yaml \
 		-p camera_info_url:=file://${HOME}/camera_calibration.yaml &
 
 micrortps_agent:
 	source /opt/ros/foxy/setup.bash && \
-	source $HOME/colcon_ws/install/setup.bash && \
+	source ${HOME}/colcon_ws/install/setup.bash && \
 	cd ${HOME}/colcon_ws && \
 	nohup micrortps_agent -t UDP &
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ xhost +local:$(docker inspect --format='{{ .Config.Hostname }}' $containerId)
 If you need to do debugging, use the following command to run a bash shell inside your container:
 
 ```bash
-docker run -it --env="DISPLAY" --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" --volume "/dev/shm:/dev/shm" --gpus all \
-  --tty --network host --entrypoint="/bin/bash" gisnav-docker_px4-sitl
+docker run -it --env="DISPLAY" --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" --volume "/dev/shm:/dev/shm" \
+  --volume="/dev/dri:/dev/dri" --gpus all --tty --network host --entrypoint="/bin/bash" gisnav-docker_px4-sitl
 ```
 
 If you are trying to connect to the PX4-ROS 2 bridge inside the container from the host but it seems like the messages 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ xhost +local:$(docker inspect --format='{{ .Config.Hostname }}' $containerId)
 If you need to do debugging, use the following command to run a bash shell inside your container:
 
 ```bash
-docker run -it --env="DISPLAY" --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" --gpus all --tty --network host \
-  --entrypoint="/bin/bash" gisnav-docker_px4-sitl
+docker run -it --env="DISPLAY" --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" --volume "/dev/shm:/dev/shm" --gpus all \
+  --tty --network host --entrypoint="/bin/bash" gisnav-docker_px4-sitl
 ```
 
 If you are trying to connect to the PX4-ROS 2 bridge inside the container from the host but it seems like the messages 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ docker run -it --env="DISPLAY" --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" --gpu
   --entrypoint="/bin/bash" gisnav-docker_px4-sitl
 ```
 
+If you are trying to connect to the PX4-ROS 2 bridge inside the container from the host but it seems like the messages 
+are not coming through, ensure your `ROS_DOMAIN_ID` environment variable on your host matches what is used inside the 
+container (0 by default):
+
+```bash
+export ROS_DOMAIN_ID=0
+```
+
 ## Repository Structure
 
 This repository is structured as follows:

--- a/README.md
+++ b/README.md
@@ -21,9 +21,14 @@ Build the Docker image:
 > Replace the example `MAPPROXY_TILE_URL` string below with your own tile-based endpoint url (e.g. WMTS). See
 > [MapProxy configuration examples][2] for more information on how to format the string.
 
+> **Note**
+> Leave out the `WITH_GISNAV` build argument if you intend to run GISNav on your host or install it separately (e.g. 
+> building a base image for automated testing of latest GISNav version in a GitHub Actions workflow)
+
 ```bash
 cd gisnav-docker
-docker-compose build --build-arg MAPPROXY_TILE_URL="https://<your-map-server-url>/tiles/%(z)s/%(y)s/%(x)s"
+docker-compose build --build-arg MAPPROXY_TILE_URL="https://<your-map-server-url>/tiles/%(z)s/%(y)s/%(x)s" \
+  --build-arg WITH_GISNAV
 ```
 
 Run the simulation:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,6 +19,7 @@ services:
       - DISPLAY=${DISPLAY}
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:ro
+      - /dev/shm:/dev/shm
     network_mode: host
     stdin_open: true
     tty: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,7 @@ services:
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix:ro
       - /dev/shm:/dev/shm
+      - /dev/dri:/dev/dri
     network_mode: host
     stdin_open: true
     tty: true

--- a/docker/px4-sitl/Dockerfile
+++ b/docker/px4-sitl/Dockerfile
@@ -1,5 +1,12 @@
 from px4io/px4-dev-ros2-foxy
 
+# Optional install GISNav build arg
+# Used e.g. for a quick demo setup, no need for ROS 2 on host. For development however it's probably best to install
+# GISNav on host and to not provide this build argument. Also for making an image to run automated tests on latest
+# development versions GISNav, it's probably best to the image without this build argument.
+ARG WITH_GISNAV
+ENV WITH_GISNAV=$WITH_GISNAV
+
 # Get a combination of commits that works together
 # In the past there have been breaking changes concerning microRTPS bridge generation
 # See e.g. https://github.com/PX4/PX4-Autopilot/pull/18052
@@ -50,6 +57,24 @@ RUN git clone https://github.com/PX4/PX4-Autopilot.git $HOME/PX4-Autopilot --rec
     git checkout $PX4_AUTOPILOT_COMMIT && \
     bash $HOME/PX4-Autopilot/Tools/setup/ubuntu.sh --no-nuttx
 
+# Install GISNav if required
+RUN if [ -z "$WITH_GISNAV" ]; \
+        then \
+            echo "Skipping GISNav installation."; \
+        else \
+            echo "Installing GISNav."; \
+            cd $HOME/colcon_ws/src; \
+            git clone --branch hmakelin-sensor-gps https://github.com/hmakelin/gisnav.git; \
+            cd gisnav; \
+            git submodule update --init gisnav/pose_estimators/third_party/LoFTR; \
+            pip3 install -r requirements.txt; \
+            pip3 install -r requirements-dev.txt; \
+            pip3 install gdown; \
+            mkdir weights; \
+            cd weights; \
+            $HOME/.local/lib/$USERNAME/gdown https://drive.google.com/uc?id=1M-VD35-qdB5Iw-AtbDBCKC7hPolFW9UY; \
+    fi
+
 # Mock GPS demo simulation configuration for typhoon_h480 build target
 # In the future these should probably be made simulation parameters and not hard-coded here
 RUN printf "\n\
@@ -69,8 +94,14 @@ RUN sudo mv configure_urtps_bridge_topics.py $HOME/ &&\
 
 # Generate topics definition file for px4_ros_com and build ROS 2 workspace
 RUN cd $HOME/PX4-Autopilot/Tools && sudo ./update_px4_ros2_bridge.sh --ws_dir $HOME/colcon_ws --all
-RUN cd $HOME/colcon_ws/src/px4_ros_com/scripts &&\
-    ./build_ros2_workspace.bash
+RUN cd $HOME/colcon_ws/ &&\
+    src/px4_ros_com/scripts/build_ros2_workspace.bash --verbose
+
+# --symlink-install (build_ros2_workspace.bash script) does not work with gisnav so re-build here if needed
+RUN if ! [ -z "$WITH_GISNAV" ]; then \
+        cd $HOME/colcon_ws && \
+            colcon build --packages-select gisnav; \
+    fi
 
 # Before building PX4 target:
 # Use non-default gst_udp_port so that QGC does not block the video stream
@@ -86,7 +117,7 @@ RUN cd $HOME/PX4-Autopilot && \
 RUN sudo apt-get -y install joystick jstest-gtk libcanberra-gtk-module libcanberra-gtk3-module
 RUN mkdir -p $HOME/.config && \
     cd "$_" && \
-    touch jstest-gtk
+    sudo touch jstest-gtk
 
 COPY yaml/camera_calibration.yaml /
 RUN sudo mv camera_calibration.yaml $HOME/

--- a/docker/px4-sitl/Dockerfile
+++ b/docker/px4-sitl/Dockerfile
@@ -28,6 +28,9 @@ RUN sudo apt-get install -y ros-foxy-gscam
 
 # Install QGroundControl
 RUN sudo apt-get install libfuse2
+RUN sudo apt-get -y remove modemmanager
+RUN sudo apt-get -y install gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-gl
+RUN sudo apt-get -y install libqt5gui5
 RUN wget -P $HOME https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.AppImage
 RUN chmod +x $HOME/QGroundControl.AppImage
 

--- a/docker/px4-sitl/Dockerfile
+++ b/docker/px4-sitl/Dockerfile
@@ -64,7 +64,7 @@ RUN if [ -z "$WITH_GISNAV" ]; \
         else \
             echo "Installing GISNav."; \
             cd $HOME/colcon_ws/src; \
-            git clone --branch hmakelin-sensor-gps https://github.com/hmakelin/gisnav.git; \
+            git clone https://github.com/hmakelin/gisnav.git; \
             cd gisnav; \
             git submodule update --init gisnav/pose_estimators/third_party/LoFTR; \
             pip3 install -r requirements.txt; \

--- a/docker/px4-sitl/Dockerfile
+++ b/docker/px4-sitl/Dockerfile
@@ -82,6 +82,12 @@ RUN cd $HOME/PX4-Autopilot/Tools/sitl_gazebo/scripts && \
 RUN cd $HOME/PX4-Autopilot && \
     make px4_sitl_rtps
 
+# Install controller/joystick support
+RUN sudo apt-get -y install joystick jstest-gtk libcanberra-gtk-module libcanberra-gtk3-module
+RUN mkdir -p $HOME/.config && \
+    cd "$_" && \
+    touch jstest-gtk
+
 COPY yaml/camera_calibration.yaml /
 RUN sudo mv camera_calibration.yaml $HOME/
 

--- a/docker/px4-sitl/Dockerfile
+++ b/docker/px4-sitl/Dockerfile
@@ -83,6 +83,7 @@ COPY Makefile /
 RUN sudo mv Makefile $HOME/
 
 # See https://docs.ros.org/en/dashing/Concepts/About-Domain-ID.html
-ENV ROS_DOMAIN_ID=0
+ARG ROS_DOMAIN_ID=0
+ENV ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
 
 CMD cd $HOME && make HOME=$HOME gazebo

--- a/docker/px4-sitl/Dockerfile
+++ b/docker/px4-sitl/Dockerfile
@@ -1,5 +1,12 @@
 from px4io/px4-dev-ros2-foxy
 
+# Get a combination of commits that works together
+# In the past there have been breaking changes concerning microRTPS bridge generation
+# See e.g. https://github.com/PX4/PX4-Autopilot/pull/18052
+ARG PX4_AUTOPILOT_COMMIT=deb938fceaa79b927ae0f622d8b2b8c4ad10d391
+ARG PX4_ROS_COM_COMMIT=90538d841a383fe9631b7046096f9aa808a43121
+ARG PX4_MSGS_COMMIT=7f89976091235579633935b7ccaab68b2debbe19
+
 # Need --fix-missing to get OpenGL to work
 RUN apt-get --fix-missing update && apt-get -y install sudo
 
@@ -16,18 +23,40 @@ USER $USERNAME
 RUN sudo apt-get -y install --reinstall xserver-xorg-video-intel libgl1-mesa-glx libgl1-mesa-dri xserver-xorg-core && \
     sudo dpkg-reconfigure xserver-xorg
 
-# Install PX4-Autopilot
-RUN git clone --branch v1.12.3 https://github.com/PX4/PX4-Autopilot.git $HOME/PX4-Autopilot --recursive &&\
-    bash $HOME/PX4-Autopilot/Tools/setup/ubuntu.sh
-
 # Install gscam
 RUN sudo apt-get install -y ros-foxy-gscam
 
-## Build ROS 2 workspace and PX4-ROS 2 bridge
-RUN git clone https://github.com/PX4/px4_ros_com.git $HOME/colcon_ws/src/px4_ros_com &&\
-    git clone https://github.com/PX4/px4_msgs.git $HOME/colcon_ws/src/px4_msgs
-RUN cd $HOME/colcon_ws/src/px4_ros_com/scripts &&\
-    ./build_ros2_workspace.bash
+# Install QGroundControl
+RUN sudo apt-get install libfuse2
+RUN wget -P $HOME https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.AppImage
+RUN chmod +x $HOME/QGroundControl.AppImage
+
+# Clone px4_ros_com
+RUN git clone https://github.com/PX4/px4_ros_com.git $HOME/colcon_ws/src/px4_ros_com && \
+    cd $HOME/colcon_ws/src/px4_ros_com && \
+    git checkout $PX4_ROS_COM_COMMIT
+
+# Clone px4_msgs
+RUN git clone https://github.com/PX4/px4_msgs.git $HOME/colcon_ws/src/px4_msgs && \
+    cd $HOME/colcon_ws/src/px4_msgs && \
+    git checkout $PX4_MSGS_COMMIT
+
+# Install PX4-Autopilot
+RUN git clone https://github.com/PX4/PX4-Autopilot.git $HOME/PX4-Autopilot --recursive && \
+    cd $HOME/PX4-Autopilot && \
+    git checkout $PX4_AUTOPILOT_COMMIT && \
+    bash $HOME/PX4-Autopilot/Tools/setup/ubuntu.sh --no-nuttx
+
+# Mock GPS demo simulation configuration for typhoon_h480 build target
+# In the future these should probably be made simulation parameters and not hard-coded here
+RUN printf "\n\
+param set-default NAV_ACC_RAD 20.0\n\
+param set-default MPC_YAWRAUTO_MAX 10.0\n\
+param set-default COM_POS_FS_DELAY 5\n\
+param set-default EKF2_GPS_P_NOISE 10\n\
+param set-default EKF2_GPS_V_NOISE 3\n\
+param set-default SENS_GPS_MASK 2\n\
+" >> $HOME/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/airframes/6011_typhoon_h480
 
 # Install pyyaml dependency and run the Python script
 RUN pip3 install empy pyros-genmsg setuptools pyyaml
@@ -35,14 +64,14 @@ COPY scripts/configure_urtps_bridge_topics.py /
 RUN sudo mv configure_urtps_bridge_topics.py $HOME/ &&\
     python3 $HOME/configure_urtps_bridge_topics.py
 
-# Increase typhoon_h480 build target GPS measurement noise
-RUN echo "param set-default EKF2_GPS_P_NOISE 1" >> \
-    $HOME/PX4-Autopilot/ROMFS/px4fmu_common/init.d-posix/airframes/6011_typhoon_h480
+# Generate topics definition file for px4_ros_com and build ROS 2 workspace
+RUN cd $HOME/PX4-Autopilot/Tools && sudo ./update_px4_ros2_bridge.sh --ws_dir $HOME/colcon_ws --all
+RUN cd $HOME/colcon_ws/src/px4_ros_com/scripts &&\
+    ./build_ros2_workspace.bash
 
-# Install QGroundControl
-RUN sudo apt-get install libfuse2
-RUN wget -P $HOME https://d176tv9ibo4jno.cloudfront.net/latest/QGroundControl.AppImage
-RUN chmod +x $HOME/QGroundControl.AppImage
+# Make initial PX4 build
+RUN cd $HOME/PX4-Autopilot && \
+    make px4_sitl_rtps
 
 COPY yaml/camera_calibration.yaml /
 RUN sudo mv camera_calibration.yaml $HOME/
@@ -52,9 +81,5 @@ RUN sudo mv gscam_params.yaml $HOME/
 
 COPY Makefile /
 RUN sudo mv Makefile $HOME/
-
-# Run check to make subsequent builds faster
-RUN cd $HOME/PX4-Autopilot && \
-    make check_px4_sitl_rtps gazebo_typhoon_h480__ksql_airport
 
 CMD cd $HOME && make HOME=$HOME gazebo

--- a/docker/px4-sitl/Dockerfile
+++ b/docker/px4-sitl/Dockerfile
@@ -82,4 +82,7 @@ RUN sudo mv gscam_params.yaml $HOME/
 COPY Makefile /
 RUN sudo mv Makefile $HOME/
 
+# See https://docs.ros.org/en/dashing/Concepts/About-Domain-ID.html
+ENV ROS_DOMAIN_ID=0
+
 CMD cd $HOME && make HOME=$HOME gazebo

--- a/docker/px4-sitl/Dockerfile
+++ b/docker/px4-sitl/Dockerfile
@@ -72,6 +72,12 @@ RUN cd $HOME/PX4-Autopilot/Tools && sudo ./update_px4_ros2_bridge.sh --ws_dir $H
 RUN cd $HOME/colcon_ws/src/px4_ros_com/scripts &&\
     ./build_ros2_workspace.bash
 
+# Before building PX4 target:
+# Use non-default gst_udp_port so that QGC does not block the video stream
+# TODO: make less brittle, might break or introduce unintended effects if jinja_gen.py is changed
+RUN cd $HOME/PX4-Autopilot/Tools/sitl_gazebo/scripts && \
+    sed -i '0,/5600/{s//5601/}' jinja_gen.py
+
 # Make initial PX4 build
 RUN cd $HOME/PX4-Autopilot && \
     make px4_sitl_rtps

--- a/yaml/gscam_params.yaml
+++ b/yaml/gscam_params.yaml
@@ -1,7 +1,7 @@
 gscam_publisher:
   ros__parameters:
     gscam_config: >
-      gst-launch-1.0 udpsrc uri=udp://127.0.0.1:5600 !
+      gst-launch-1.0 udpsrc uri=udp://127.0.0.1:5601 !
       application/x-rtp,media=video,clock-rate=90000,encoding-name=H264 !
       rtph264depay ! h264parse ! avdec_h264 ! videoconvert
     preroll: False


### PR DESCRIPTION
Changes to make the container compatible with PX4-Autopilot v1.13:

- Uses new `urtps_bridge_topics.yaml` file instead of old `uorb_rtps_message_ids.yaml`
- `VehicleGpsPosition` swapped for new `SensorGps` message (makes this container incompatible with current version of `gisnav`, see new GISNav PR to fix this: https://github.com/hmakelin/gisnav/pull/8)

Improvements:

- Reorders the `px4-sitl` Dockerfile commands so that more stable items are built first and configuration is done last

Fixes some bugs:

- Formatting of `HOME` environment variable in Makefile
- `ROS_DOMAIN_ID` environment variable is now set to 0

Other:

- An updated configuration of PX4 parameters for `MockGPSNode` demo is hard-coded into the `px4-sitl` Dockerfile for now, should probably move this elsewhere later
- Makes it possible to run GISNav on host while SITL simulation runs inside the containe by enabling SharedMemory between host and container