### PR TITLE
Adds MapServer service to docker-compose.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,20 @@
 # GISNav SITL Simulation Environment
 
 This repository provides Docker scripts for building and running a PX4 SITL simulation environment for testing GISNav.
-The `px4-sitl` container launches a PX4 SITL simulation in Gazebo along with QGroundControl, `micrortps_agent` and 
-`gscam`, while the standalone `mapproxy` container runs a MapProxy WMS (proxy) server.
 
-## Quick Start
+The following services are included:
+* The `px4-sitl` service launches a PX4 SITL simulation in Gazebo along with supporting services, excluding the WMS
+  endpoint.
+* The `mapserver` service leverages the `camptocamp/mapserver` image on Docker Hub to add a WMS endpoint with locally 
+  hosted high-resolution aerial imagery from [NAIP][1] that covers the SITL simulation area.
+* The `mapproxy` service can be used as an alternative WMS endpoint for development and testing if you already have a 
+  tile-based endpoint for high-resolution imagery available.
 
-If you have an NVIDIA GPU on your host machine, make sure you have [NVIDIA Container Toolkit installed][1].
+## Quick start
+
+### Setup
+
+If you have an NVIDIA GPU on your host machine, make sure you have [NVIDIA Container Toolkit installed][2].
 
 Clone this repository:
 
@@ -15,65 +23,93 @@ cd $HOME
 git clone https://github.com/hmakelin/gisnav-docker.git
 ```
 
-Build the Docker image:
-
-> **Note**
-> Replace the example `MAPPROXY_TILE_URL` string below with your own tile-based endpoint url (e.g. WMTS). See
-> [MapProxy configuration examples][2] for more information on how to format the string.
+### Option 1: With embedded maps (`mapserver` + `px4-sitl`)
+Build the images:
 
 > **Note**
 > Leave out the `WITH_GISNAV` build argument if you intend to run GISNav on your host or install it separately (e.g. 
-> building a base image for automated testing of latest GISNav version in a GitHub Actions workflow)
+> building a base image for automated testing of latest GISNav version in a GitHub Actions workflow).
 
 ```bash
-cd gisnav-docker
-docker-compose build --build-arg MAPPROXY_TILE_URL="https://<your-map-server-url>/tiles/%(z)s/%(y)s/%(x)s" \
-  --build-arg WITH_GISNAV
+cd $HOME/gisnav-docker
+docker-compose build mapserver px4-sitl --build-arg WITH_GISNAV
 ```
 
-Run the simulation:
+Run the containers:
 
 ```bash
-docker-compose up -d
+docker-compose up -d mapserver px4-sitl
 ```
 
-Stop the simulation:
+### Option 2: With MapProxy (`mapproxy` + `px4-sitl`)
+
+Build the images:
+
+> **Note**
+> * Replace the example `MAPPROXY_TILE_URL` string below with your own tile-based endpoint url (e.g. WMTS). See
+>   [MapProxy configuration examples][3] for more information on how to format the string.
+> * Leave out the `WITH_GISNAV` build argument if you intend to run GISNav on your host or install it separately (e.g. 
+>   building a base image for automated testing of latest GISNav version in a GitHub Actions workflow).
 
 ```bash
+cd $HOME/gisnav-docker
+docker-compose build mapproxy mapserver \
+  --build-arg WITH_GISNAV \
+  --build-arg MAPPROXY_TILE_URL="https://<your-map-server-url>/tiles/%(z)s/%(y)s/%(x)s" \
+```
+
+Run the containers:
+
+```bash
+docker-compose up -d mapproxy px4-sitl
+```
+
+### Shutdown all services
+
+```bash
+cd $HOME/gisnav-docker
 docker-compose down
 ```
 
-To run Gazebo in headless mode (for automated testing, for example), pass the `GAZEBO_HEADLESS=1` environment variable 
-when you run your container:
-
-```bash
-GAZEBO_HEADLESS=1 docker-compose up -d
-```
-
-## Troubleshooting
+### Troubleshooting
 
 If the Gazebo and QGroundControl windows do not appear on your screen some time after running your container (may take 
 several minutes the first time when it builds your image), you may need to expose your ``xhost`` to your Docker 
-container as described in the [ROS GUI Tutorial][3]:
+container as described in the [ROS GUI Tutorial][4]:
 
 ```bash
 export containerId=$(docker ps -l -q)
 xhost +local:$(docker inspect --format='{{ .Config.Hostname }}' $containerId)
 ```
 
-If you need to do debugging, use the following command to run a bash shell inside your container:
-
-```bash
-docker run -it --env="DISPLAY" --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" --volume "/dev/shm:/dev/shm" \
-  --volume="/dev/dri:/dev/dri" --gpus all --tty --network host --entrypoint="/bin/bash" gisnav-docker_px4-sitl
-```
-
 If you are trying to connect to the PX4-ROS 2 bridge inside the container from the host but it seems like the messages 
 are not coming through, ensure your `ROS_DOMAIN_ID` environment variable on your host matches what is used inside the 
-container (0 by default):
+container *(0 by default)*:
 
 ```bash
 export ROS_DOMAIN_ID=0
+```
+
+If the Gazebo simulation feels slow or you are doing automated testing, you can run it in headless mode by passing the 
+`GAZEBO_HEADLESS=1` environment variable:
+
+```bash
+GAZEBO_HEADLESS=1 docker-compose up -d mapserver px4-sitl
+```
+
+If you need to do debugging on `px4-sitl`, you can use the following command to run a bash shell inside your container:
+
+```bash
+docker run -it \
+  --env="DISPLAY" \
+  --volume="/tmp/.X11-unix:/tmp/.X11-unix:rw" \
+  --volume "/dev/shm:/dev/shm" \
+  --volume="/dev/dri:/dev/dri" \
+  --gpus all \
+  --tty \
+  --network host \
+  --entrypoint="/bin/bash" \
+  gisnav-docker_px4-sitl
 ```
 
 ## Repository Structure
@@ -90,21 +126,25 @@ This repository is structured as follows:
 ├── docker-compose.yaml
 ├── LICENSE.md
 ├── Makefile                                # Makefile used by px4-sitl (used inside container, not on host)
+├── mapfiles
+│    └── wms.map                            # Mapfile for setting up WMS on MapServer
 ├── README.md
 ├── scripts
 │    └── configure_urtps_bridge_topics.py   # Configuration script used by px4-sitl
+│    └── setup_mapserver.hs                 # Configuration script used by mapserver
 └── yaml
     ├── camera_calibration.yaml             # Configuration file used by px4-sitl
     ├── gscam_params.yaml                   # Configuration file used by px4-sitl
     └── mapproxy.yaml                       # Configuration file used by mapproxy
 
-5 directories, 10 files
+6 directories, 12 files
 ```
 
 ## License
 
 This software is released under the MIT license. See the `LICENSE.md` file for more information.
 
-[1]: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
-[2]: https://mapproxy.org/docs/latest/configuration_examples.html
-[3]: http://wiki.ros.org/docker/Tutorials/GUI
+[1]: https://en.wikipedia.org/wiki/National_Agriculture_Imagery_Program
+[2]: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
+[3]: https://mapproxy.org/docs/latest/configuration_examples.html
+[4]: http://wiki.ros.org/docker/Tutorials/GUI

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,18 @@
 version: "3"
 
 services:
+  mapserver:
+    image: camptocamp/mapserver
+    ports:
+      - "80:80"
+    environment:
+      - GDOWN_ID=16M_kbsLpF3t87KC2n9YgqGEBA5h0lG7U
+      - MAPSERVER_PATH=/etc/mapserver
+    volumes:
+      - $PWD/mapfiles/wms.map:$MAPSERVER_PATH/wms.map:ro
+      - $PWD/scripts/setup_mapserver.sh:$MAPSERVER_PATH/setup_mapserver.sh:ro
+    entrypoint: $MAPSERVER_PATH/setup_mapserver.sh
+
   mapproxy:
     build:
       context: .

--- a/mapfiles/wms.map
+++ b/mapfiles/wms.map
@@ -1,0 +1,24 @@
+MAP
+  NAME "GISNav WMS"
+  PROJECTION
+    "init=epsg:4326"
+  END
+  EXTENT -122.3153963 37.4973779 -122.1845578 37.5650967
+  WEB
+    METADATA
+        "wms_title"           "GISNav WMS NAIP Imagery"
+        "wms_onlineresource"  "http://localhost:8080/?map=/etc/mapserver/wms.map"
+        "wms_srs"             "EPSG:3857 EPSG:4326"
+        "wms_enable_request"  "GetMap GetCapabilities"
+    END
+  END
+  LAYER
+    NAME          "naip-natural-color-raster"
+    DATA          "/etc/mapserver/naip.vrt"
+    STATUS DEFAULT
+    TYPE RASTER
+    PROJECTION
+      "init=epsg:26910"
+    END
+  END
+END

--- a/scripts/setup_mapserver.sh
+++ b/scripts/setup_mapserver.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+# Downloads NAIP imagery and creates a VRT file in the appropriate folder for the
+# camptocamp/mapserver Docker container.
+
+# Check that the map raster Google Drive link was provided
+if [ -z "$GDOWN_ID" ]; then \
+  tput setaf 1; \
+  echo -e "\$GDOWN_ID is empty! Provide it with --env GDOWN_ID=\"url\"."; \
+  tput sgr0; \
+  exit 1; \
+fi
+
+cd /etc/mapserver
+
+# Download NAIP imagery
+ZIP_FILENAME="usda-fsa-naip-san-mateo-ca-2020.zip"  # does not have to match uploaded file name
+apt-get update && apt-get -y install unzip python3-pip
+pip3 install gdown
+if ! [ -f "$ZIP_FILENAME" ]; then \
+  echo -e "Downloading NAIP imagery."; \
+  gdown $GDOWN_URL -O $ZIP_FILENAME; \
+  unzip $ZIP_FILENAME; \
+fi
+
+# Create VRT file from NAIP GeoTIFFs
+# VRT file name should match with what is configured in Mapfile
+VRT_FILENAME="naip.vrt"
+if ! [ -f "$VRT_FILENAME" ]; then \
+  echo -e "Creating VRT file."; \
+  gdalbuildvrt $VRT_FILENAME *.tif; \
+fi
+
+# Setup complete, start MapServer
+/usr/local/bin/start-server


### PR DESCRIPTION
The new service when run downloads NAIP imagery from Google Drive and embeds it with the MapServer. No need for external WMS endpoint or Internet connection, can run "onboard" once appropriate maps are uploaded.