### PR TITLE
Include flight plan on SITL container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,11 +7,10 @@ services:
       - "80:80"
     environment:
       - GDOWN_ID=16M_kbsLpF3t87KC2n9YgqGEBA5h0lG7U
-      - MAPSERVER_PATH=/etc/mapserver
     volumes:
-      - $PWD/mapfiles/wms.map:$MAPSERVER_PATH/wms.map:ro
-      - $PWD/scripts/setup_mapserver.sh:$MAPSERVER_PATH/setup_mapserver.sh:ro
-    entrypoint: $MAPSERVER_PATH/setup_mapserver.sh
+      - $PWD/mapfiles/wms.map:/etc/mapserver/wms.map:ro
+      - $PWD/scripts/setup_mapserver.sh:/etc/mapserver/setup_mapserver.sh:ro
+    entrypoint: /etc/mapserver/setup_mapserver.sh
 
   mapproxy:
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,3 +35,8 @@ services:
     network_mode: host
     stdin_open: true
     tty: true
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [ gpu ]

--- a/docker/px4-sitl/Dockerfile
+++ b/docker/px4-sitl/Dockerfile
@@ -125,6 +125,9 @@ RUN sudo mv camera_calibration.yaml $HOME/
 COPY yaml/gscam_params.yaml /
 RUN sudo mv gscam_params.yaml $HOME/
 
+COPY flight_plans/ksql_airport.plan /
+RUN sudo mv ksql_airport.plan $HOME/
+
 COPY Makefile /
 RUN sudo mv Makefile $HOME/
 

--- a/docker/px4-sitl/Dockerfile
+++ b/docker/px4-sitl/Dockerfile
@@ -10,7 +10,7 @@ ENV WITH_GISNAV=$WITH_GISNAV
 # Get a combination of commits that works together
 # In the past there have been breaking changes concerning microRTPS bridge generation
 # See e.g. https://github.com/PX4/PX4-Autopilot/pull/18052
-ARG PX4_AUTOPILOT_COMMIT=deb938fceaa79b927ae0f622d8b2b8c4ad10d391
+ARG PX4_AUTOPILOT_COMMIT=715afd27f58a89d31aa4289a4b8681fb0e5014e9
 ARG PX4_ROS_COM_COMMIT=90538d841a383fe9631b7046096f9aa808a43121
 ARG PX4_MSGS_COMMIT=7f89976091235579633935b7ccaab68b2debbe19
 

--- a/flight_plans/ksql_airport.plan
+++ b/flight_plans/ksql_airport.plan
@@ -1,0 +1,175 @@
+{
+    "fileType": "Plan",
+    "geoFence": {
+        "circles": [
+        ],
+        "polygons": [
+        ],
+        "version": 2
+    },
+    "groundStation": "QGroundControl",
+    "mission": {
+        "cruiseSpeed": 15,
+        "firmwareType": 12,
+        "globalPlanAltitudeMode": 1,
+        "hoverSpeed": 5,
+        "items": [
+            {
+                "autoContinue": true,
+                "command": 530,
+                "doJumpId": 1,
+                "frame": 2,
+                "params": [
+                    0,
+                    2,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "autoContinue": true,
+                "command": 205,
+                "doJumpId": 2,
+                "frame": 2,
+                "params": [
+                    -90,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    2
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 130,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 22,
+                "doJumpId": 3,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.523640799999995,
+                    -122.2551034,
+                    130
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 130,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 4,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.5243677,
+                    -122.256137,
+                    130
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 130,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 5,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.5253963,
+                    -122.2548594,
+                    130
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 130,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 6,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.5225601,
+                    -122.25639389999999,
+                    130
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": null,
+                "Altitude": 130,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 7,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.5226161,
+                    -122.2543137,
+                    130
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "autoContinue": true,
+                "command": 20,
+                "doJumpId": 8,
+                "frame": 2,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
+                ],
+                "type": "SimpleItem"
+            }
+        ],
+        "plannedHomePosition": [
+            37.52364104097109,
+            -122.25510340000132,
+            2.7443970797736887
+        ],
+        "vehicleType": 2,
+        "version": 2
+    },
+    "rallyPoints": {
+        "points": [
+        ],
+        "version": 2
+    },
+    "version": 1
+}

--- a/flight_plans/ksql_airport.plan
+++ b/flight_plans/ksql_airport.plan
@@ -36,7 +36,7 @@
                 "doJumpId": 2,
                 "frame": 2,
                 "params": [
-                    -90,
+                    -85,
                     0,
                     0,
                     0,
@@ -47,7 +47,7 @@
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 130,
                 "Altitude": 130,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -59,14 +59,14 @@
                     0,
                     0,
                     null,
-                    37.523640799999995,
-                    -122.2551034,
+                    37.5236489,
+                    -122.2551101,
                     130
                 ],
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 130,
                 "Altitude": 130,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -78,14 +78,14 @@
                     0,
                     0,
                     null,
-                    37.5243677,
-                    -122.256137,
+                    37.52371697,
+                    -122.25300218,
                     130
                 ],
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 130,
                 "Altitude": 130,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -97,14 +97,14 @@
                     0,
                     0,
                     null,
-                    37.5253963,
-                    -122.2548594,
+                    37.52176837,
+                    -122.2531202,
                     130
                 ],
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 130,
                 "Altitude": 130,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -116,14 +116,14 @@
                     0,
                     0,
                     null,
-                    37.5225601,
-                    -122.25639389999999,
+                    37.52190452,
+                    -122.25684311,
                     130
                 ],
                 "type": "SimpleItem"
             },
             {
-                "AMSLAltAboveTerrain": null,
+                "AMSLAltAboveTerrain": 130,
                 "Altitude": 130,
                 "AltitudeMode": 1,
                 "autoContinue": true,
@@ -135,8 +135,27 @@
                     0,
                     0,
                     null,
-                    37.5226161,
-                    -122.2543137,
+                    37.52347872,
+                    -122.25807692,
+                    130
+                ],
+                "type": "SimpleItem"
+            },
+            {
+                "AMSLAltAboveTerrain": 130,
+                "Altitude": 130,
+                "AltitudeMode": 1,
+                "autoContinue": true,
+                "command": 16,
+                "doJumpId": 8,
+                "frame": 3,
+                "params": [
+                    0,
+                    0,
+                    0,
+                    null,
+                    37.52461893,
+                    -122.25681092,
                     130
                 ],
                 "type": "SimpleItem"
@@ -144,7 +163,7 @@
             {
                 "autoContinue": true,
                 "command": 20,
-                "doJumpId": 8,
+                "doJumpId": 9,
                 "frame": 2,
                 "params": [
                     0,
@@ -159,9 +178,9 @@
             }
         ],
         "plannedHomePosition": [
-            37.52364104097109,
-            -122.25510340000132,
-            2.7443970797736887
+            37.5236489,
+            -122.2551101,
+            2.673999185660817
         ],
         "vehicleType": 2,
         "version": 2


### PR DESCRIPTION
- For the MockGPSDemo a premade flight plan is needed (for convenience).
- Fixes a bug in the mapserver docker-compose script.