### PR TITLE
Simulation path update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ gisnav:
 			echo "WITH_GISNAV env variable not provided for build, will not attempt to run GISNav."; \
 		else \
 			echo "Running GISNav."; \
+			echo "nvidia-smi output:"; \
+			nvidia-smi; \
 			source /opt/ros/foxy/setup.bash; \
 			source ${HOME}/colcon_ws/install/setup.bash; \
 			cd ${HOME}/colcon_ws; \

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ gisnav:
 		then \
 			echo "WITH_GISNAV env variable not provided for build, will not attempt to run GISNav."; \
 		else \
+			echo "Running GISNav."; \
 			source /opt/ros/foxy/setup.bash; \
 			source ${HOME}/colcon_ws/install/setup.bash; \
 			cd ${HOME}/colcon_ws; \

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,4 +39,6 @@ services:
       resources:
         reservations:
           devices:
-            - capabilities: [ gpu ]
+            - driver: nvidia
+              count: 1
+              capabilities: [ gpu ]

--- a/docker/px4-sitl/Dockerfile
+++ b/docker/px4-sitl/Dockerfile
@@ -106,7 +106,7 @@ RUN if ! [ -z "$WITH_GISNAV" ]; then \
 # Before building PX4 target:
 # Use non-default gst_udp_port so that QGC does not block the video stream
 # TODO: make less brittle, might break or introduce unintended effects if jinja_gen.py is changed
-RUN cd $HOME/PX4-Autopilot/Tools/sitl_gazebo/scripts && \
+RUN cd $HOME/PX4-Autopilot/Tools/simulation/gazebo/sitl_gazebo/scripts && \
     sed -i '0,/5600/{s//5601/}' jinja_gen.py
 
 # Make initial PX4 build

--- a/docker/px4-sitl/Dockerfile
+++ b/docker/px4-sitl/Dockerfile
@@ -135,4 +135,4 @@ RUN sudo mv Makefile $HOME/
 ARG ROS_DOMAIN_ID=0
 ENV ROS_DOMAIN_ID=${ROS_DOMAIN_ID}
 
-CMD cd $HOME && make HOME=$HOME gazebo
+CMD cd $HOME && make HOME=$HOME WITH_GISNAV=$WITH_GISNAV gazebo

--- a/docker/px4-sitl/Dockerfile
+++ b/docker/px4-sitl/Dockerfile
@@ -119,6 +119,9 @@ RUN mkdir -p $HOME/.config && \
     cd "$_" && \
     sudo touch jstest-gtk
 
+# Install some utilities
+RUN sudo sudo apt-get -y install ~nros-foxy-rqt* vim
+
 COPY yaml/camera_calibration.yaml /
 RUN sudo mv camera_calibration.yaml $HOME/
 


### PR DESCRIPTION
- Updates the `sitl_gazebo` submodule path after recent upstream change
- Makes GPU work with container also when run with docker-compose
- Adds `rqt` and `vim` inside container since they have been useful for debugging