### PR TITLE
Add rasterized OSM Buildings height data

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 This repository provides Docker scripts for building portable SITL development, testing and demonstration 
 environments for [GISNav][1]. The `docker-compose.yaml` file defines the following services:
 
-| Service name                | Description                                                                  | Intended use                                                                                                                                                |
-|-----------------------------|------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| <nobr>`px4-sitl`</nobr>     | PX4 SITL Gazebo simulation **including GISNav**, and excluding WMS endpoint. | Mainly for demonstration (see [mock GPS demo][2]).                                                                                                          |
-| <nobr>`px4-sitl-dev`</nobr> | PX4 SITL Gazebo simulation **excluding GISNav**, and excluding WMS endpoint. | (1) Development where GISNav is installed locally on the host, and (2) automated testing where GISNav is installed during a CI workflow.                    |
-| <nobr>`mapserver`</nobr>    | WMS server with locally hosted imagery from [NAIP][3] covering KSQL airport. | For development, testing, and demonstration (see [mock GPS demo][2]).                                                                                       |
-| <nobr>`mapproxy`</nobr>     | WMS proxy for existing remote tile-based imagery endpoint.                   | For testing when imagery layer needs to cover multiple flight regions (over presumedly multiple test scenarios covering too large an area to host locally). |
+| Service name                | Description                                                                                      | Intended use                                                                                                                                                |
+|-----------------------------|--------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| <nobr>`px4-sitl`</nobr>     | PX4 SITL Gazebo simulation **including GISNav**, and excluding WMS endpoint.                     | Mainly for demonstration (see [mock GPS demo][2]).                                                                                                          |
+| <nobr>`px4-sitl-dev`</nobr> | PX4 SITL Gazebo simulation **excluding GISNav**, and excluding WMS endpoint.                     | (1) Development where GISNav is installed locally on the host, and (2) automated testing where GISNav is installed during a CI workflow.                    |
+| <nobr>`mapserver`</nobr>    | WMS server with locally hosted data from [NAIP][3] and [OSM Buildings][4] covering KSQL airport. | For development, testing, and demonstration (see [mock GPS demo][2]).                                                                                       |
+| <nobr>`mapproxy`</nobr>     | WMS proxy for existing remote tile-based imagery endpoint.                                       | For testing when imagery layer needs to cover multiple flight regions (over presumedly multiple test scenarios covering too large an area to host locally). |
 
 ## Quick Start
 
@@ -16,7 +16,7 @@ Follow these instructions to build the Docker images that are needed to run the 
 
 ### Setup
 
-If you have an NVIDIA GPU on your host machine, make sure you have [NVIDIA Container Toolkit installed][4].
+If you have an NVIDIA GPU on your host machine, make sure you have [NVIDIA Container Toolkit installed][5].
 
 Clone this repository and change to its root directory:
 
@@ -38,7 +38,7 @@ docker-compose up mapserver px4-sitl
 
 > **Note**
 > * Replace the example `MAPPROXY_TILE_URL` string below with your own tile-based endpoint url (e.g. WMTS). See
->   [MapProxy configuration examples][5] for more information on how to format the string.
+>   [MapProxy configuration examples][6] for more information on how to format the string.
 
 ```bash
 docker-compose build \
@@ -56,7 +56,7 @@ docker-compose down
 ## Troubleshooting
 
 If the Gazebo and QGroundControl windows do not appear on your screen soon after running your container you may need to 
-expose your ``xhost`` to your Docker container as described in the [ROS GUI Tutorial][6]:
+expose your ``xhost`` to your Docker container as described in the [ROS GUI Tutorial][7]:
 
 ```bash
 export containerId=$(docker ps -l -q)
@@ -70,7 +70,7 @@ If you do not seem to be receiving any telemetry from the container to your host
 export ROS_DOMAIN_ID=0
 ```
 
-If you are doing automated testing ([e.g. with mavsdk][7]), you can run Gazebo in headless mode and not launch 
+If you are doing automated testing ([e.g. with mavsdk][8]), you can run Gazebo in headless mode and not launch 
 QGroundControl by setting `GAZEBO_HEADLESS=1` and `LAUNCH_QGC=0`:
 
 ```bash
@@ -131,7 +131,8 @@ This software is released under the MIT license. See the `LICENSE.md` file for m
 [1]: https://github.com/hmakelin/gisnav
 [2]: https://github.com/hmakelin/gisnav/blob/master/README.md#mock-gps-example
 [3]: https://en.wikipedia.org/wiki/National_Agriculture_Imagery_Program
-[4]: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
-[5]: https://mapproxy.org/docs/latest/configuration_examples.html
-[6]: http://wiki.ros.org/docker/Tutorials/GUI
-[7]: https://github.com/hmakelin/gisnav/blob/master/test/sitl/sitl_test_mock_gps_node.py
+[4]: https://osmbuildings.org/
+[5]: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
+[6]: https://mapproxy.org/docs/latest/configuration_examples.html
+[7]: http://wiki.ros.org/docker/Tutorials/GUI
+[8]: https://github.com/hmakelin/gisnav/blob/master/test/sitl/sitl_test_mock_gps_node.py

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,8 @@ services:
     ports:
       - "80:80"
     environment:
-      - GDOWN_ID=16M_kbsLpF3t87KC2n9YgqGEBA5h0lG7U
+      - NAIP_GDOWN_ID=16M_kbsLpF3t87KC2n9YgqGEBA5h0lG7U
+      - OSM_GDOWN_ID=1snGYjWxs71m6I-qxKsmUzch_bAfQtrEW
     volumes:
       - $PWD/mapfiles/mapserver.map:/etc/mapserver/mapserver.map:ro
       - $PWD/scripts/setup_mapserver.sh:/etc/mapserver/setup_mapserver.sh:ro

--- a/mapfiles/mapserver.map
+++ b/mapfiles/mapserver.map
@@ -1,5 +1,5 @@
 MAP
-  NAME "GISNav WMS"
+  NAME "GISNav OGC WMS"
   PROJECTION
     "init=epsg:4326"
   END
@@ -19,6 +19,15 @@ MAP
     TYPE RASTER
     PROJECTION
       "init=epsg:26910"
+    END
+  END
+  LAYER
+    NAME          "osm-buildings"
+    DATA          "/etc/mapserver/osm-buildings-ksql-airport.tif"
+    STATUS DEFAULT
+    TYPE RASTER
+    PROJECTION
+      "init=epsg:4326"
     END
   END
 END

--- a/mapfiles/mapserver.map
+++ b/mapfiles/mapserver.map
@@ -24,7 +24,6 @@ MAP
   LAYER
     NAME          "osm-buildings"
     DATA          "/etc/mapserver/osm-buildings-ksql-airport.tif"
-    STATUS DEFAULT
     TYPE RASTER
     PROJECTION
       "init=epsg:4326"

--- a/mapfiles/mapserver.map
+++ b/mapfiles/mapserver.map
@@ -15,7 +15,6 @@ MAP
   LAYER
     NAME          "imagery"
     DATA          "/etc/mapserver/naip.vrt"
-    STATUS DEFAULT
     TYPE RASTER
     PROJECTION
       "init=epsg:26910"

--- a/scripts/setup_mapserver.sh
+++ b/scripts/setup_mapserver.sh
@@ -1,26 +1,39 @@
 #!/bin/sh
 
-# Downloads NAIP imagery and creates a VRT file in the appropriate folder for the
+# Downloads NAIP imagery, OSM Buildings data, and creates a VRT file in the appropriate folder for the
 # camptocamp/mapserver Docker container.
 
-# Check that the map raster Google Drive link was provided
-if [ -z "$GDOWN_ID" ]; then \
+# Check that the NAIP map raster Google Drive link was provided
+if [ -z "$NAIP_GDOWN_ID" ]; then \
   tput setaf 1; \
-  echo -e "\$GDOWN_ID is empty! Provide it with --env GDOWN_ID=\"url\"."; \
+  echo -e "\$NAIP_GDOWN_ID is empty! Provide it with --env NAIP_GDOWN_ID=\"url\"."; \
   tput sgr0; \
   exit 1; \
 fi
 
 cd /etc/mapserver
 
-# Download NAIP imagery
-ZIP_FILENAME="usda-fsa-naip-san-mateo-ca-2020.zip"  # does not have to match uploaded file name
+# Install tools to download and unzip maps from Google Drive
 apt-get update && apt-get -y install unzip python3-pip
 pip3 install gdown
-if ! [ -f "$ZIP_FILENAME" ]; then \
-  echo -e "Downloading NAIP imagery."; \
-  gdown $GDOWN_ID -O $ZIP_FILENAME; \
-  unzip $ZIP_FILENAME; \
+
+# Download NAIP raster imagery
+NAIP_ZIP_FILENAME="usda-fsa-naip-san-mateo-ca-2020.zip"  # does not have to match uploaded file name
+if ! [ -f "$NAIP_ZIP_FILENAME" ]; then \
+  echo -e "Downloading NAIP imagery..."; \
+  gdown $NAIP_GDOWN_ID -O $NAIP_ZIP_FILENAME; \
+  unzip $NAIP_ZIP_FILENAME; \
+fi
+
+# Download OSM Buildings vector data if download ID given
+OSM_ZIP_FILENAME="osm-buildings-ksql-airport.zip"  # does not have to match uploaded file name
+if ! [ -z "$OSM_GDOWN_ID" ]; \
+  then \
+    echo -e "Downloading OSM Buildings data..."; \
+    gdown $OSM_GDOWN_ID -O $OSM_ZIP_FILENAME; \
+    unzip $OSM_ZIP_FILENAME; \
+  else \
+    echo -e "No download ID for OSM Buildings data provided, skipping download."; \
 fi
 
 # Create VRT file from NAIP GeoTIFFs
@@ -30,6 +43,19 @@ if ! [ -f "$VRT_FILENAME" ]; then \
   echo -e "Creating VRT file."; \
   gdalbuildvrt $VRT_FILENAME *.tif; \
 fi
+
+# Rasterize OSM Buildings vectors into a VRT file
+OSM_ZIP_FILENAME="osm-buildings-ksql-airport.zip"  # does not have to match uploaded file name
+if ! [ -z "$OSM_GDOWN_ID" ]; \
+  then \
+    echo -e "Rasterizing OSM Buildings data..."; \
+    gdal_rasterize -a height -ts $(gdalinfo $VRT_FILENAME |grep "Size is" |cut -d\  -f3-4 |sed "s/,//") \
+      osm-buildings-ksql-airport.geojson \
+      osm-buildings-ksql-airport.tif
+  else \
+    echo -e "No download ID for OSM Buildings data provided, skipping rasterization."; \
+fi
+
 
 # Setup complete, start MapServer
 /usr/local/bin/start-server

--- a/scripts/setup_mapserver.sh
+++ b/scripts/setup_mapserver.sh
@@ -27,13 +27,13 @@ fi
 
 # Download OSM Buildings vector data if download ID given
 OSM_ZIP_FILENAME="osm-buildings-ksql-airport.zip"  # does not have to match uploaded file name
-if ! [ -z "$OSM_GDOWN_ID" ]; \
+if ! [ -z "$OSM_GDOWN_ID" ] && ! [ -f "$OSM_ZIP_FILENAME" ]; \
   then \
     echo -e "Downloading OSM Buildings data..."; \
     gdown $OSM_GDOWN_ID -O $OSM_ZIP_FILENAME; \
     unzip $OSM_ZIP_FILENAME; \
   else \
-    echo -e "No download ID for OSM Buildings data provided, skipping download."; \
+    echo -e "No download ID for OSM Buildings data provided or data already downloaded, skipping download."; \
 fi
 
 # Create VRT file from NAIP GeoTIFFs


### PR DESCRIPTION
Adds rasterized OSM Buildings height data to `mapserver`. Intend to use this to improve accuracy of GISNav especially when flying at low altitude. While the source OSM Buildings height data is in vector format, it should be rasterized on the GIS server so that it will not have to be done onboard during flight (slows everything down). Eventually would also add a DEM to get ground altitude.