### PR TITLE
Add USGS digital elevation model (DEM) data and WMS layer

### DIFF
--- a/mapfiles/mapserver.map
+++ b/mapfiles/mapserver.map
@@ -33,7 +33,15 @@ MAP
     DATA          "/etc/mapserver/USGS_13_n38w123_20220810.tif"
     TYPE RASTER
     PROJECTION
-      "init=epsg:4269"
+      "init=epsg:4326"
+    END
+  END
+  LAYER
+    NAME          "osm-buildings-dem"
+    DATA          "/etc/mapserver/osm-buildings-dem.tif"
+    TYPE RASTER
+    PROJECTION
+      "init=epsg:4326"
     END
   END
 END

--- a/mapfiles/mapserver.map
+++ b/mapfiles/mapserver.map
@@ -28,4 +28,12 @@ MAP
       "init=epsg:4326"
     END
   END
+  LAYER
+    NAME          "usgs-dem"
+    DATA          "/etc/mapserver/USGS_13_n38w123_20220810.tif"
+    TYPE RASTER
+    PROJECTION
+      "init=epsg:4269"
+    END
+  END
 END

--- a/scripts/setup_mapserver.sh
+++ b/scripts/setup_mapserver.sh
@@ -6,7 +6,7 @@
 # Check that the NAIP map raster Google Drive link was provided
 if [ -z "$NAIP_GDOWN_ID" ]; then \
   tput setaf 1; \
-  echo -e "\$NAIP_GDOWN_ID is empty! Provide it with --env NAIP_GDOWN_ID=\"url\"."; \
+  echo "\$NAIP_GDOWN_ID is empty! Provide it with --env NAIP_GDOWN_ID=\"url\"."; \
   tput sgr0; \
   exit 1; \
 fi
@@ -14,13 +14,13 @@ fi
 cd /etc/mapserver
 
 # Install tools to download and unzip maps from Google Drive
-apt-get update && apt-get -y install unzip python3-pip
+apt-get update && apt-get -y install unzip python3-pip wget
 pip3 install gdown
 
 # Download NAIP raster imagery
 NAIP_ZIP_FILENAME="usda-fsa-naip-san-mateo-ca-2020.zip"  # does not have to match uploaded file name
 if ! [ -f "$NAIP_ZIP_FILENAME" ]; then \
-  echo -e "Downloading NAIP imagery..."; \
+  echo "Downloading NAIP imagery..."; \
   gdown $NAIP_GDOWN_ID -O $NAIP_ZIP_FILENAME; \
   unzip $NAIP_ZIP_FILENAME; \
 fi
@@ -29,33 +29,44 @@ fi
 OSM_ZIP_FILENAME="osm-buildings-ksql-airport.zip"  # does not have to match uploaded file name
 if ! [ -z "$OSM_GDOWN_ID" ] && ! [ -f "$OSM_ZIP_FILENAME" ]; \
   then \
-    echo -e "Downloading OSM Buildings data..."; \
+    echo "Downloading OSM Buildings data..."; \
     gdown $OSM_GDOWN_ID -O $OSM_ZIP_FILENAME; \
     unzip $OSM_ZIP_FILENAME; \
   else \
-    echo -e "No download ID for OSM Buildings data provided or data already downloaded, skipping download."; \
+    echo "No download ID for OSM Buildings data provided or data already downloaded, skipping download."; \
 fi
 
 # Create VRT file from NAIP GeoTIFFs
 # VRT file name should match with what is configured in Mapfile
 VRT_FILENAME="naip.vrt"
 if ! [ -f "$VRT_FILENAME" ]; then \
-  echo -e "Creating VRT file."; \
+  echo "Creating VRT file."; \
   gdalbuildvrt $VRT_FILENAME *.tif; \
 fi
 
 # Rasterize OSM Buildings vectors into a VRT file
 OSM_ZIP_FILENAME="osm-buildings-ksql-airport.zip"  # does not have to match uploaded file name
-if ! [ -z "$OSM_GDOWN_ID" ]; \
+OSM_TIF_FILENAME="osm-buildings-ksql-airport.tif"
+if ! [ -z "$OSM_GDOWN_ID" ] && ! [ -f "$OSM_TIF_FILENAME" ]; \
   then \
-    echo -e "Rasterizing OSM Buildings data..."; \
+    echo "Rasterizing OSM Buildings data..."; \
     gdal_rasterize -a height -ts $(gdalinfo $VRT_FILENAME |grep "Size is" |cut -d\  -f3-4 |sed "s/,//") \
       osm-buildings-ksql-airport.geojson \
-      osm-buildings-ksql-airport.tif
+      $OSM_TIF_FILENAME
   else \
-    echo -e "No download ID for OSM Buildings data provided, skipping rasterization."; \
+    echo "No download ID for OSM Buildings data provided or raster already exists, skipping rasterization."; \
 fi
 
+# Download USGS DEM: https://www.sciencebase.gov/catalog/item/62f5de86d34eacf53973ab2a
+# Attribution: "Map services and data available from U.S. Geological Survey, National Geospatial Program."
+DEM_FILENAME="USGS_13_n38w123_20220810.tif"
+if ! [ -f "$DEM_FILENAME" ]; \
+  then \
+    echo "Downloading digital elevation model (DEM)..."; \
+    wget "https://prd-tnm.s3.amazonaws.com/StagedProducts/Elevation/13/TIFF/historical/n38w123/USGS_13_n38w123_20220810.tif"
+  else \
+    echo "Digital elevation model (DEM) already downloaded."; \
+fi
 
 # Setup complete, start MapServer with default mapfile
 MS_MAPFILE=/etc/mapserver/mapserver.map


### PR DESCRIPTION
Downloads [this DEM](https://www.sciencebase.gov/catalog/item/62f5de86d34eacf53973ab2a) from USGS when running mapserver and serves it as another WMS layer (`usgs-dem`). This new layer can be requested together with the existing `osm-buildings` layer to form a composite elevation layer that describes both ground elevation and building height. 

Based on a quick inspection of the `usgs-dem`layer in QGIS, **the resolution of the DEM seems to be low enough that it mostly "ignores" the buildings so that their height does not get added twice if a compound layer is requested.**

ATTRIBUTION: [Map services and data available from U.S. Geological Survey, National Geospatial Program.](https://www.usgs.gov/faqs/what-are-terms-uselicensing-map-services-and-data-national-map)